### PR TITLE
feat: docker support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and Push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Generate artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Runs in a single container on one port. No configuration required - start the co
 
 ## Quick Start
 
+### Using Pre-built Docker Image (Recommended)
+
+```bash
+docker run -d --name gpu-hot --gpus all -p 1312:1312 ghcr.io/psalias2006/gpu-hot:latest
+```
+
+Open `http://localhost:1312`
+
+### Building from Source
+
 ```bash
 docker-compose up --build
 ```
@@ -91,7 +101,13 @@ This is the middle ground: web interface with charts, zero configuration.
 
 ## Installation
 
-### Docker (Recommended)
+### Pre-built Image (Easiest)
+
+```bash
+docker run -d --name gpu-hot --gpus all -p 1312:1312 ghcr.io/psalias2006/gpu-hot:latest
+```
+
+### Build from Source
 
 ```bash
 git clone https://github.com/psalias2006/gpu-hot


### PR DESCRIPTION
This PR adds Github Container Registry support for gpu-hot.

We use netdata to monitor our rigs but this is great from a quick per-node view at a glance, we run podman so we thought having an official image would  make it easier to use.

When you merge to main, this workflow will publish a new image for you - or when you create a tag. No config required (uses `GITHUB_TOKEN`) so no extra secrets etc.

Users can skip the build step and run directly:

```
docker run -d --gpus all -p 1312:1312 ghcr.io/psalias2006/gpu-hot:latest
```