### PR TITLE
build that docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,11 +43,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and Push Docker image


### PR DESCRIPTION

Builds to the `main` branch worked fine.

### Root Cause
The workflow was generating a SHA-based tag with `type=sha,prefix={{branch}}-` for all events. When pushing a tag (not a branch), the `{{branch}}` variable is empty, resulting in an invalid tag format like `:-7b8ecc8`.

### Solution
Simplified the Docker tagging strategy to be cleaner and more appropriate for a small project:

**Before:**
- Multiple semver patterns (`{{version}}`, `{{major}}.{{minor}}`, `{{major}}`)
- SHA-based tags with branch prefix
- PR tags

**After:**
- `type=ref,event=branch` - Tags for branch pushes (e.g., `main`)
- `type=semver,pattern={{version}}` - Exact version for tags (e.g., `1.2.3`)
- `type=raw,value=latest` - Latest tag for main branch only

### Result
**For version tags (`v1.2.3`):**
- `ghcr.io/psalias2006/gpu-hot:1.2.3`

**For main branch pushes:**
- `ghcr.io/psalias2006/gpu-hot:main`
- `ghcr.io/psalias2006/gpu-hot:latest`

This provides a clean, minimal tagging strategy without the complexity of multiple semver patterns that aren't necessary for a small project.