### PR TITLE
Broadcast on node update instead of a fixed timer

### DIFF
--- a/core/hub.py
+++ b/core/hub.py
@@ -19,7 +19,8 @@ class Hub:
         self.url_to_node = {}  # url -> node_name mapping
         self.running = False
         self._connection_started = False
-        
+        self._update_event = None  # created lazily on the running loop
+
         # Initialize nodes as offline
         for url in node_urls:
             self.nodes[url] = {
@@ -30,7 +31,27 @@ class Hub:
                 'last_update': None
             }
             self.url_to_node[url] = url
-    
+
+    def _get_update_event(self):
+        """Lazily create the update event so it binds to the running loop."""
+        if self._update_event is None:
+            self._update_event = asyncio.Event()
+        return self._update_event
+
+    def signal_update(self):
+        """Wake the broadcast loop — a node's data or status changed."""
+        self._get_update_event().set()
+
+    async def wait_for_update(self, timeout):
+        """Block until a node delivers new data, or until timeout (heartbeat)."""
+        event = self._get_update_event()
+        try:
+            await asyncio.wait_for(event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            event.clear()
+
     async def _connect_all_nodes(self):
         """Connect to all nodes in background with retries"""
         # Wait a bit for Docker network to be ready
@@ -77,7 +98,8 @@ class Hub:
                         'status': 'online',
                         'last_update': datetime.now().isoformat()
                     }
-                    
+                    self.signal_update()
+
                     # Listen for data from the node
                     async for message in websocket:
                         try:
@@ -97,7 +119,8 @@ class Hub:
                                 'status': 'online',
                                 'last_update': datetime.now().isoformat()
                             }
-                            
+                            self.signal_update()
+
                         except json.JSONDecodeError as e:
                             logger.error(f'Failed to parse message from {url}: {e}')
                         except Exception as e:
@@ -110,6 +133,7 @@ class Hub:
                 if node_name in self.nodes:
                     self.nodes[node_name]['status'] = 'offline'
                     logger.info(f'Marked node {node_name} as offline')
+                    self.signal_update()
             except Exception as e:
                 logger.error(f'Failed to connect to node {url}: {e}')
                 # Mark node as offline
@@ -117,6 +141,7 @@ class Hub:
                 if node_name in self.nodes:
                     self.nodes[node_name]['status'] = 'offline'
                     logger.info(f'Marked node {node_name} as offline')
+                    self.signal_update()
             
             # Wait before retrying connection
             if self.running:

--- a/core/hub_handlers.py
+++ b/core/hub_handlers.py
@@ -7,6 +7,9 @@ from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)
 
+# Heartbeat fallback so the event-driven loop still re-checks hub.running when nodes are idle
+HEARTBEAT_INTERVAL = 5.0
+
 # Global WebSocket connections
 websocket_connections = set()
 
@@ -43,28 +46,28 @@ def register_hub_handlers(app, hub):
 
 
 async def hub_loop(hub, connections):
-    """Async background loop that emits aggregated cluster data"""
+    """Async background loop that broadcasts aggregated cluster data on each node update"""
     logger.info("Hub monitoring loop started")
-    
+
     while hub.running:
         try:
             cluster_data = await hub.get_cluster_data()
-            
-            # Send to all connected clients
+
+            # Send to all connected clients (copy to avoid mutation during iteration)
             if connections:
                 disconnected = set()
-                for websocket in connections:
+                for websocket in list(connections):
                     try:
                         await websocket.send_text(json.dumps(cluster_data))
-                    except:
+                    except Exception:
                         disconnected.add(websocket)
-                
+
                 # Remove disconnected clients
                 connections -= disconnected
-                
+
         except Exception as e:
             logger.error(f"Error in hub loop: {e}")
-        
-        # Match node update rate for real-time responsiveness
-        await asyncio.sleep(0.5)
+
+        # Wake on the next node update; timeout is just the heartbeat
+        await hub.wait_for_update(timeout=HEARTBEAT_INTERVAL)
 


### PR DESCRIPTION
The hub receives node data over persistent WebSockets but re-broadcasts to dashboard clients on a hardcoded 0.5s, so it re-sends stale frames and ignores each node's rate. Broadcast when a node delivers new data or changes status (with a heartbeat fallback), so the hub follows each node's rate, which is what the loop comment already promises.

Closes #68. Supersedes the quick fix #70 on the same line, so take one or the other.

Assisted by Claude (Opus 4.8), reviewed by me.
