### PR TITLE
Honour UPDATE_INTERVAL in hub mode

### DIFF
--- a/core/hub_handlers.py
+++ b/core/hub_handlers.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import json
 from fastapi import WebSocket
+from . import config
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,6 @@ async def hub_loop(hub, connections):
         except Exception as e:
             logger.error(f"Error in hub loop: {e}")
         
-        # Match node update rate for real-time responsiveness
-        await asyncio.sleep(0.5)
+        # Broadcast interval to dashboard clients (configurable, default 0.5s)
+        await asyncio.sleep(config.UPDATE_INTERVAL)
 


### PR DESCRIPTION
In hub mode the dashboard broadcast loop uses a hardcoded 0.5s, so `UPDATE_INTERVAL` has no effect there. Use `config.UPDATE_INTERVAL` (default 0.5s, unchanged) so operators can slow the hub to match slower nodes.

Quick fix for #68, superseded by the event-driven approach #69 if you'd rather take that instead.

Assisted by Claude (Opus 4.8), reviewed by me.
