### PR TITLE
Cap nvidia-smi refresh instead of throttling the whole loop

### DIFF
--- a/core/handlers.py
+++ b/core/handlers.py
@@ -42,14 +42,16 @@ def register_handlers(app, monitor):
 
 async def monitor_loop(monitor, connections):
     """Async background loop that collects and emits GPU data"""
-    # Determine update interval based on whether any GPU uses nvidia-smi
-    uses_nvidia_smi = any(monitor.use_smi.values()) if hasattr(monitor, 'use_smi') else False
-    update_interval = config.NVIDIA_SMI_INTERVAL if uses_nvidia_smi else config.UPDATE_INTERVAL
-    
-    if uses_nvidia_smi:
-        logger.info(f"Using nvidia-smi polling interval: {update_interval}s")
+    # Tick at UPDATE_INTERVAL unless every GPU is on smi (nvidia-smi refresh is capped in the monitor)
+    use_smi = getattr(monitor, 'use_smi', {}) or {}
+    all_smi = bool(use_smi) and all(use_smi.values())
+    update_interval = config.NVIDIA_SMI_INTERVAL if all_smi else config.UPDATE_INTERVAL
+
+    if any(use_smi.values()):
+        logger.info(f"Monitor loop interval: {update_interval}s "
+                    f"(nvidia-smi refresh capped at {config.NVIDIA_SMI_INTERVAL}s)")
     else:
-        logger.info(f"Using NVML polling interval: {update_interval}s")
+        logger.info(f"Monitor loop interval: {update_interval}s")
     
     while monitor.running:
         try:

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -1,12 +1,13 @@
 """Async GPU monitoring using NVML"""
 
 import asyncio
+import time
 import pynvml
 import psutil
 import logging
 from .metrics import MetricsCollector
 from .nvidia_smi_fallback import parse_nvidia_smi
-from .config import NVIDIA_SMI
+from .config import NVIDIA_SMI, NVIDIA_SMI_INTERVAL
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,8 @@ class GPUMonitor:
         self.gpu_data = {}
         self.collector = MetricsCollector()
         self.use_smi = {}  # Track which GPUs use nvidia-smi (decided at boot)
+        self._smi_cache = None  # Last nvidia-smi result
+        self._smi_last_ts = 0.0  # Monotonic time of last nvidia-smi refresh
 
         try:
             pynvml.nvmlInit()
@@ -89,16 +92,23 @@ class GPUMonitor:
             device_count = pynvml.nvmlDeviceGetCount()
             gpu_data = {}
 
-            # Get nvidia-smi data once if any GPU needs it
+            # Refresh nvidia-smi at most once per NVIDIA_SMI_INTERVAL so it doesn't throttle NVML GPUs
             smi_data = None
             if any(self.use_smi.values()):
-                try:
-                    # Run nvidia-smi in thread pool to avoid blocking
-                    smi_data = await asyncio.get_event_loop().run_in_executor(
-                        None, parse_nvidia_smi
-                    )
-                except Exception as e:
-                    logger.error(f"nvidia-smi failed: {e}")
+                now = time.monotonic()
+                if self._smi_cache is None or (now - self._smi_last_ts) >= NVIDIA_SMI_INTERVAL:
+                    try:
+                        # Run nvidia-smi in thread pool to avoid blocking
+                        smi_data = await asyncio.get_event_loop().run_in_executor(
+                            None, parse_nvidia_smi
+                        )
+                        self._smi_cache = smi_data
+                        self._smi_last_ts = now
+                    except Exception as e:
+                        logger.error(f"nvidia-smi failed: {e}")
+                        smi_data = self._smi_cache  # reuse last good data
+                else:
+                    smi_data = self._smi_cache
 
             # Collect GPU data concurrently
             tasks = []


### PR DESCRIPTION
On a box where some GPUs use NVML and others fall back to nvidia-smi, `monitor_loop` picks the slow `NVIDIA_SMI_INTERVAL` for the whole loop whenever any GPU is on smi, so healthy NVML GPUs get sampled at the slow rate too.

Tick at `UPDATE_INTERVAL` and refresh nvidia-smi at most once per `NVIDIA_SMI_INTERVAL` (cached in between), so NVML GPUs sample fast regardless of smi GPUs. Only when every GPU is on smi does the loop tick at the slower rate. Default single-backend behaviour is unchanged.

Assisted by Claude (Opus 4.8), reviewed by me.
